### PR TITLE
Merge to main: Fix bug where Cloud Logging read requests per minute quota was being reached

### DIFF
--- a/python_collector_app/app.py
+++ b/python_collector_app/app.py
@@ -456,35 +456,68 @@ def acm_export(asset_parent):
 # Auth logs of users from Cloud Logging export
 def user_auth_ip_export(hours):
     """Retrieves project authentication logs in the last X hours
+
     Args:
         hours (int): number of hours to filter logs
 
     Returns:
         A list of authentication log entries (if any)
     """
+	
     auth_log_client = google.cloud.logging.Client(project=project_id)
     now = datetime.now(timezone.utc)
     time_hours_ago = now - timedelta(hours=hours)
-    filter_str = f'timestamp >= "{time_hours_ago.isoformat()}" \
-                   AND logName="projects/{project_id}/logs/cloudaudit.googleapis.com%2Factivity" \
-                   -protoPayload.serviceName="iam.googleapis.com" \
-                   -protoPayload.serviceName="k8s.io"'
+
+    filter_str = f'''
+        timestamp >= "{time_hours_ago.isoformat()}" 
+        AND logName="projects/{project_id}/logs/cloudaudit.googleapis.com%2Factivity"
+        -protoPayload.serviceName="iam.googleapis.com"
+        -protoPayload.serviceName="k8s.io"
+    '''
+    logger.info("Compiling GCP User Auth data")
     try:
         entries = auth_log_client.list_entries(filter_=filter_str)
     except Exception as e:
         logger.error(f"Error retrieving logs from Cloud Logging: {e}")
+        return json.dumps([], separators=(',', ':'))
+
     user_auth_logs_list = []
-    try:
-        for entry in entries:
-            principal_email = entry.payload['authenticationInfo']['principalEmail']
-            source_ip = entry.payload['requestMetadata']['callerIp']
-            caller_user_agent = entry.payload['requestMetadata']['callerSuppliedUserAgent']
-            # excluding cloudshell, gsa and internal auths
-            if 'environment/devshell' not in caller_user_agent and not principal_email.endswith('iam.gserviceaccount.com') and source_ip != 'private':
-                # insertId can be used to find specific log entry
-                user_auth_logs_list.append({"kind": "logging#user#auth", "logName": entry.log_name, "insertId": entry.insert_id, "principalEmail": principal_email, "sourceIp": source_ip, "timestamp": entry.timestamp.isoformat()})
-    except KeyError:
-        pass
+
+    for entry in entries:
+        payload = entry.payload
+        if not isinstance(payload, dict):
+            continue
+
+        auth_info = payload.get('authenticationInfo')
+        request_metadata = payload.get('requestMetadata')
+
+        if not isinstance(auth_info, dict) or not isinstance(request_metadata, dict):
+            continue
+
+        principal_email = auth_info.get('principalEmail')
+        source_ip = request_metadata.get('callerIp')
+        caller_user_agent = request_metadata.get('callerSuppliedUserAgent')
+
+        if not all([principal_email, source_ip, caller_user_agent]):
+            continue
+
+        # Exclude internal/cloudshell/service accounts
+        if 'environment/devshell' in caller_user_agent:
+            continue
+        if principal_email.endswith('iam.gserviceaccount.com'):
+            continue
+        if source_ip == 'private':
+            continue
+
+        user_auth_logs_list.append({
+            "kind": "logging#user#auth",
+            "logName": entry.log_name,
+            "insertId": entry.insert_id,
+            "principalEmail": principal_email,
+            "sourceIp": source_ip,
+            "timestamp": entry.timestamp.isoformat()
+        })
+
     return json.dumps(user_auth_logs_list, separators=(',', ':'))
 
 # Org Admin Group member export


### PR DESCRIPTION
Implemented some logic to address an issue whereby the read requests per minute API limit is being hit during log collection.

1) Increased the `page_size` value from `50` (default) to `250`. This tracks the number of entries to fetch in each API call. Can potentially raise higher if performance isn't being impacted.

2) Added a value called `log_read_requests_per_min` that pulls from an env var, or defaults to 60 which is the default quota value in GCP.

3) Added some logic to divide 60 by the `log_read_requests_per_min` value to determine how many seconds each API call should `sleep` before trying again. This ensures that it won't go over the limit set per minute.