### PR TITLE
Replace request library with httpx library, enable http/2 support

### DIFF
--- a/python_collector_app/app.py
+++ b/python_collector_app/app.py
@@ -23,6 +23,7 @@ import time
 import re
 from datetime import datetime, timedelta, timezone
 from cryptography import x509
+import httpx
 
 # Logger setup
 logger = logging.getLogger()
@@ -829,7 +830,8 @@ def upload_json():
 
     time.sleep(5)
     # Evaluate compiled data
-    response = requests.post("http://localhost:8181/v1/data/main/guardrail", json=compiled_data)
+    client = httpx.Client(http2=True)
+    response = client.post("http://localhost:8181/v1/data/main/guardrail", json=compiled_data, timeout=10.0)
     if response.ok:
         response_data = response.json()
         try:

--- a/python_collector_app/requirements.txt
+++ b/python_collector_app/requirements.txt
@@ -11,3 +11,4 @@ google-cloud-securitycenter == 1.38.1
 google-api-python-client == 2.156.0
 cryptography == 44.0.2
 google-api-core == 2.24.0
+httpx[http2]


### PR DESCRIPTION
Replaced the `request` library with the `httpx` library to allow for HTTP/2 support.

Ultimately this will allow for communication with the OPA server using HTTP/2, which is to resolve an issue whereby a request limit exists when using HTTP/1 that is limiting what size files you can provide the OPA server.

This should remove any limitation that exists.