### PR TITLE
Change static bucket name to bucket_name variable

### DIFF
--- a/python_collector_app/app.py
+++ b/python_collector_app/app.py
@@ -845,7 +845,7 @@ def upload_json():
         except Exception as e:
             logger.error (f"Error dowloading file{e}")
             return None
-    additional_file = read_file("compliance-hub-152207934868", "data/extra.json")
+    additional_file = read_file(bucket_name, "data/extra.json")
 
 
     # # Step 13: Compile final data


### PR DESCRIPTION
Bug fix whereby additional_file will read from the `bucket_name` var instead of static GCS bucket name.