### PR TITLE
Updated Dockerfile to use nonroot account

### DIFF
--- a/python_collector_app/Dockerfile
+++ b/python_collector_app/Dockerfile
@@ -3,25 +3,25 @@ FROM cgr.dev/chainguard/python:latest-dev AS python-build
 ENV PYTHONDONTWRITEBYTECODE=1 \
   PYTHONUNBUFFERED=1 \
   PIP_NO_CACHE_DIR=1 \
-  PATH="/app/venv/bin:$PATH"
+  PATH="/home/nonroot/app/venv/bin:$PATH"
 
-WORKDIR /app
+WORKDIR /home/nonroot/app
 
 COPY requirements.txt ./
-RUN python -m venv /app/venv && \
+RUN python -m venv /home/nonroot/app/venv && \
   pip install --no-cache-dir -r requirements.txt
 
 FROM cgr.dev/chainguard/python:latest
 
-WORKDIR /app
-
 ENV PYTHONDONTWRITEBYTECODE=1 \
   PYTHONUNBUFFERED=1 \
   PORT=8080 \
-  PATH="/app/venv/bin:${PATH}"
+  PATH="/home/nonroot/app/venv/bin:${PATH}"
 
-COPY --from=python-build /app/venv /app/venv
-COPY ["app.py", "generate_reports.py", "guardrail_manifest.json", "/app/"]
+WORKDIR /home/nonroot/app
+
+COPY --from=python-build /home/nonroot/app/venv /home/nonroot/app/venv
+COPY ["app.py", "generate_reports.py", "guardrail_manifest.json", "./"]
 
 EXPOSE 8080
 


### PR DESCRIPTION
Dockerfile now uses nonroot account for creation of venv and storage of artifacts.